### PR TITLE
fmt and lint added to github actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,3 +28,29 @@ jobs:
       - name: build
         run: |
           make build
+  golint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '1.17'
+      - uses: actions/checkout@v3
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.29
+  prettier:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ github.head_ref }}
+        fetch-depth: 0
+
+    - name: Format code
+      uses: iamnotaturtle/auto-gofmt@v1.0
+      with:
+        only_changed: True

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,14 +42,12 @@ jobs:
           version: v1.29
   prettier:
     runs-on: ubuntu-latest
-
     steps:
     - name: Checkout
       uses: actions/checkout@v2
       with:
         ref: ${{ github.head_ref }}
         fetch-depth: 0
-
     - name: Format code
       uses: iamnotaturtle/auto-gofmt@v1.0
       with:


### PR DESCRIPTION
Since the operations required the project to be built first the actions have been added to the build.yaml file